### PR TITLE
Rya-112

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ local.properties
 .classpath
 .settings/
 .loadpath
+.recommenders/
 
 # External tool builders
 .externalToolBuilders/

--- a/common/rya.api/src/main/java/mvm/rya/api/persist/index/RyaSecondaryIndexer.java
+++ b/common/rya.api/src/main/java/mvm/rya/api/persist/index/RyaSecondaryIndexer.java
@@ -34,7 +34,7 @@ import mvm.rya.api.domain.RyaURI;
 
 public interface RyaSecondaryIndexer extends Closeable, Flushable, Configurable {
 
-    public String getTableName();
+    public String getTableName(); // TODO: some indexers have multiple tables, should return a list.
 
     public void storeStatements(Collection<RyaStatement> statements) throws IOException;
 

--- a/common/rya.api/src/main/java/mvm/rya/api/persist/index/RyaSecondaryIndexer.java
+++ b/common/rya.api/src/main/java/mvm/rya/api/persist/index/RyaSecondaryIndexer.java
@@ -34,7 +34,14 @@ import mvm.rya.api.domain.RyaURI;
 
 public interface RyaSecondaryIndexer extends Closeable, Flushable, Configurable {
 
-    public String getTableName(); // TODO: some indexers have multiple tables, should return a list.
+	/**
+	 * 
+	 * Returns the table name if the implementation supports it.
+	 * Note that some indexers use multiple tables, this only returns one.
+	 * 
+     * @return table name as a string.
+	 */
+    public String getTableName(); 
 
     public void storeStatements(Collection<RyaStatement> statements) throws IOException;
 

--- a/dao/accumulo.rya/src/main/java/mvm/rya/accumulo/AccumuloRyaDAO.java
+++ b/dao/accumulo.rya/src/main/java/mvm/rya/accumulo/AccumuloRyaDAO.java
@@ -489,7 +489,7 @@ public class AccumuloRyaDAO implements RyaDAO<AccumuloRdfConfiguration>, RyaName
 
         // Additional Tables
         for (AccumuloIndexer index : secondaryIndexers) {
-            tableNames.add(index.getTableName());
+            tableNames.add(index.getTableName());  // TODO: some indexers have multiple tables, should return a list.
         }
 
         return tableNames.toArray(new String[]{});

--- a/dao/accumulo.rya/src/main/java/mvm/rya/accumulo/AccumuloRyaDAO.java
+++ b/dao/accumulo.rya/src/main/java/mvm/rya/accumulo/AccumuloRyaDAO.java
@@ -489,7 +489,7 @@ public class AccumuloRyaDAO implements RyaDAO<AccumuloRdfConfiguration>, RyaName
 
         // Additional Tables
         for (AccumuloIndexer index : secondaryIndexers) {
-            tableNames.add(index.getTableName());  // TODO: some indexers have multiple tables, should return a list.
+            tableNames.add(index.getTableName());
         }
 
         return tableNames.toArray(new String[]{});

--- a/dao/mongodb.rya/src/main/java/mvm/rya/mongodb/instance/MongoDetailsAdapter.java
+++ b/dao/mongodb.rya/src/main/java/mvm/rya/mongodb/instance/MongoDetailsAdapter.java
@@ -124,8 +124,12 @@ public class MongoDetailsAdapter {
             pcjBuilder.add(PCJ_FLUO_KEY, pcjDetails.getFluoDetails().get().getUpdateAppName());
         }
         final List<DBObject> pcjDetailList = new ArrayList<>();
+<<<<<<< 64c0caa14162a0b3f2603cc080ed187a0d2bd1ae
         for(final Entry<String, PCJDetails> entry : pcjDetails.getPCJDetails().entrySet()) {
             final PCJDetails pcjDetail = entry.getValue();
+=======
+        for(final PCJDetails pcjDetail : pcjDetails.getPCJDetails()) {
+>>>>>>> RYA-84 Add Mongo Support to Admin Table
             final BasicDBObjectBuilder indBuilbder = BasicDBObjectBuilder.start()
                 .add(PCJ_ID_KEY, pcjDetail.getId())
                 .add(PCJ_UPDATE_STRAT_KEY, pcjDetail.getUpdateStrategy().name());

--- a/dao/mongodb.rya/src/main/java/mvm/rya/mongodb/instance/MongoDetailsAdapter.java
+++ b/dao/mongodb.rya/src/main/java/mvm/rya/mongodb/instance/MongoDetailsAdapter.java
@@ -124,12 +124,8 @@ public class MongoDetailsAdapter {
             pcjBuilder.add(PCJ_FLUO_KEY, pcjDetails.getFluoDetails().get().getUpdateAppName());
         }
         final List<DBObject> pcjDetailList = new ArrayList<>();
-<<<<<<< 64c0caa14162a0b3f2603cc080ed187a0d2bd1ae
         for(final Entry<String, PCJDetails> entry : pcjDetails.getPCJDetails().entrySet()) {
             final PCJDetails pcjDetail = entry.getValue();
-=======
-        for(final PCJDetails pcjDetail : pcjDetails.getPCJDetails()) {
->>>>>>> RYA-84 Add Mongo Support to Admin Table
             final BasicDBObjectBuilder indBuilbder = BasicDBObjectBuilder.start()
                 .add(PCJ_ID_KEY, pcjDetail.getId())
                 .add(PCJ_UPDATE_STRAT_KEY, pcjDetail.getUpdateStrategy().name());

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
@@ -23,6 +23,7 @@ package mvm.rya.indexing.accumulo;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import mvm.rya.accumulo.AccumuloRdfConfiguration;
@@ -54,7 +55,6 @@ import org.apache.accumulo.core.client.ZooKeeperInstance;
 import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.client.mock.MockInstance;
 import org.apache.accumulo.core.security.Authorizations;
-import org.apache.commons.lang.Validate;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.util.ReflectionUtils;
@@ -67,8 +67,7 @@ import com.google.common.collect.Lists;
 
 /**
  * A set of configuration utils to read a Hadoop {@link Configuration} object and create Cloudbase/Accumulo objects.
- * Soon will deprecated this class.  Use installer for the set methods, use RyaDetails for the get methods. 
- * Use {@link RyaDetails} or {@link ConfigurationFields}
+ * Soon will deprecate this class.  Use installer for the set methods, use {@link RyaDetails} for the get methods. 
  * New code must separate parameters that are set at Rya install time from that which is specific to the client.
  * Also Accumulo index tables are pushed down to the implementation and not configured in conf.   
  */
@@ -88,12 +87,7 @@ public class ConfigUtils {
 
     public static final String FREE_TEXT_QUERY_TERM_LIMIT = "sc.freetext.querytermlimit";
 
-//    public static final String FREE_TEXT_DOC_TABLENAME = "sc.freetext.doctable";
-//    public static final String FREE_TEXT_TERM_TABLENAME = "sc.freetext.termtable";
-//    public static final String GEO_TABLENAME = "sc.geo.table";
     public static final String GEO_NUM_PARTITIONS = "sc.geo.numPartitions";
-//    public static final String TEMPORAL_TABLENAME = "sc.temporal.index";
-//    public static final String ENTITY_TABLENAME = "sc.entity.index";
 
     public static final String USE_GEO = "sc.use_geo";
     public static final String USE_FREETEXT = "sc.use_freetext";
@@ -146,7 +140,7 @@ public class ConfigUtils {
      */
     private static String getStringCheckSet(final Configuration conf, final String key) {
         final String value = conf.get(key);
-        Validate.notNull(value, key + " not set");
+        Objects.requireNonNull(value, key + " not set");
         return value;
     }
 
@@ -170,18 +164,18 @@ public class ConfigUtils {
     }
 
     /**
-     * Lookup the table name prefix and throw an error if it is null.
-     * TODO get table prefix from RyaDetails
-     * @param conf
-     * @return
+     * Lookup the table name prefix in the conf and throw an error if it is null.
+     * TODO get table prefix from RyaDetails -- the Rya instance name
+     * @param conf  Rya configuration map where it extracts the prefix (instance name)
+     * @return  index table prefix corresponding to this Rya instance
      */
-	public static String getTablePrefix(final Configuration conf) {
-		final String tablePrefix;
-		tablePrefix = conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX);
-		Validate.notNull(tablePrefix, RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX + " not set.  Cannot generate table name.");
-		return tablePrefix;
-	}
-
+    public static String getTablePrefix(final Configuration conf) {
+        final String tablePrefix;
+        tablePrefix = conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX);
+        Objects.requireNonNull(tablePrefix, "Configuration key: " + RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX
+                + " not set.  Cannot generate table name.");
+        return tablePrefix;
+    }
 
     public static int getFreeTextTermLimit(final Configuration conf) {
         return conf.getInt(FREE_TEXT_QUERY_TERM_LIMIT, 100);

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/ConfigUtils.java
@@ -67,6 +67,10 @@ import com.google.common.collect.Lists;
 
 /**
  * A set of configuration utils to read a Hadoop {@link Configuration} object and create Cloudbase/Accumulo objects.
+ * Soon will deprecated this class.  Use installer for the set methods, use RyaDetails for the get methods. 
+ * Use {@link RyaDetails} or {@link ConfigurationFields}
+ * New code must separate parameters that are set at Rya install time from that which is specific to the client.
+ * Also Accumulo index tables are pushed down to the implementation and not configured in conf.   
  */
 public class ConfigUtils {
     private static final Logger logger = Logger.getLogger(ConfigUtils.class);
@@ -84,12 +88,12 @@ public class ConfigUtils {
 
     public static final String FREE_TEXT_QUERY_TERM_LIMIT = "sc.freetext.querytermlimit";
 
-    public static final String FREE_TEXT_DOC_TABLENAME = "sc.freetext.doctable";
-    public static final String FREE_TEXT_TERM_TABLENAME = "sc.freetext.termtable";
-    public static final String GEO_TABLENAME = "sc.geo.table";
+//    public static final String FREE_TEXT_DOC_TABLENAME = "sc.freetext.doctable";
+//    public static final String FREE_TEXT_TERM_TABLENAME = "sc.freetext.termtable";
+//    public static final String GEO_TABLENAME = "sc.geo.table";
     public static final String GEO_NUM_PARTITIONS = "sc.geo.numPartitions";
-    public static final String TEMPORAL_TABLENAME = "sc.temporal.index";
-    public static final String ENTITY_TABLENAME = "sc.entity.index";
+//    public static final String TEMPORAL_TABLENAME = "sc.temporal.index";
+//    public static final String ENTITY_TABLENAME = "sc.entity.index";
 
     public static final String USE_GEO = "sc.use_geo";
     public static final String USE_FREETEXT = "sc.use_freetext";
@@ -165,41 +169,23 @@ public class ConfigUtils {
         return false;
     }
 
-    private static String getIndexTableName(final Configuration conf, final String indexTableNameConf, final String altSuffix){
-        String value = conf.get(indexTableNameConf);
-        if (value == null){
-            final String defaultTableName = conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX);
-            Validate.notNull(defaultTableName, indexTableNameConf + " not set and " + RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX + " not set.  Cannot generate table name.");
-            value = conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX) + altSuffix;
-        }
-        return value;
-    }
+    /**
+     * Lookup the table name prefix and throw an error if it is null.
+     * TODO get table prefix from RyaDetails
+     * @param conf
+     * @return
+     */
+	public static String getTablePrefix(final Configuration conf) {
+		final String tablePrefix;
+		tablePrefix = conf.get(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX);
+		Validate.notNull(tablePrefix, RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX + " not set.  Cannot generate table name.");
+		return tablePrefix;
+	}
 
-    public static String getFreeTextDocTablename(final Configuration conf) {
-        return getIndexTableName(conf, FREE_TEXT_DOC_TABLENAME, "freetext");
-    }
-
-    public static String getFreeTextTermTablename(final Configuration conf) {
-        return getIndexTableName(conf, FREE_TEXT_TERM_TABLENAME, "freetext_term");
-    }
 
     public static int getFreeTextTermLimit(final Configuration conf) {
         return conf.getInt(FREE_TEXT_QUERY_TERM_LIMIT, 100);
     }
-
-    public static String getGeoTablename(final Configuration conf) {
-        return getIndexTableName(conf, GEO_TABLENAME, "geo");
-    }
-
-    public static String getTemporalTableName(final Configuration conf) {
-        return getIndexTableName(conf, TEMPORAL_TABLENAME, "temporal");
-    }
-
-
-    public static String getEntityTableName(final Configuration conf) {
-        return getIndexTableName(conf, ENTITY_TABLENAME, "entity");
-    }
-
 
     public static Set<URI> getFreeTextPredicates(final Configuration conf) {
         return getPredicates(conf, FREETEXT_PREDICATES_LIST);

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/AccumuloDocIdIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/AccumuloDocIdIndexer.java
@@ -420,7 +420,7 @@ public class AccumuloDocIdIndexer implements DocIdIndexer {
         if(query.hasContext()) {
             DocumentIndexIntersectingIterator.setContext(is, query.getContextURI());
         }
-        bs = accCon.createBatchScanner(ConfigUtils.getEntityTableName(conf),
+        bs = accCon.createBatchScanner(EntityCentricIndex.getTableName(conf),
                 new Authorizations(conf.get(ConfigUtils.CLOUDBASE_AUTHS)), 15);
         bs.addScanIterator(is);
         bs.setRanges(ranges);

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/AccumuloDocIdIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/AccumuloDocIdIndexer.java
@@ -398,9 +398,9 @@ public class AccumuloDocIdIndexer implements DocIdIndexer {
         return currentSolutionBs;
     }
 
-   private BatchScanner runQuery(StarQuery query, Collection<Range> ranges) throws QueryEvaluationException {
+    private BatchScanner runQuery(StarQuery query, Collection<Range> ranges) throws QueryEvaluationException {
 
-    try {
+        try {
             if (ranges.size() == 0) {
                 String rangeText = query.getCommonVarValue();
                 Range r;
@@ -412,31 +412,25 @@ public class AccumuloDocIdIndexer implements DocIdIndexer {
                 ranges = Collections.singleton(r);
             }
 
-        Connector accCon = ConfigUtils.getConnector(conf);
-        IteratorSetting is = new IteratorSetting(30, "fii", DocumentIndexIntersectingIterator.class);
+            Connector accCon = ConfigUtils.getConnector(conf);
+            IteratorSetting is = new IteratorSetting(30, "fii", DocumentIndexIntersectingIterator.class);
 
-        DocumentIndexIntersectingIterator.setColumnFamilies(is, query.getColumnCond());
+            DocumentIndexIntersectingIterator.setColumnFamilies(is, query.getColumnCond());
 
-        if(query.hasContext()) {
-            DocumentIndexIntersectingIterator.setContext(is, query.getContextURI());
+            if (query.hasContext()) {
+                DocumentIndexIntersectingIterator.setContext(is, query.getContextURI());
+            }
+            bs = accCon.createBatchScanner(EntityCentricIndex.getTableName(conf),
+                    new Authorizations(conf.get(ConfigUtils.CLOUDBASE_AUTHS)), 15);
+            bs.addScanIterator(is);
+            bs.setRanges(ranges);
+
+            return bs;
+
+        } catch (TableNotFoundException | AccumuloException | AccumuloSecurityException e) {
+            throw new QueryEvaluationException(e);
         }
-        bs = accCon.createBatchScanner(EntityCentricIndex.getTableName(conf),
-                new Authorizations(conf.get(ConfigUtils.CLOUDBASE_AUTHS)), 15);
-        bs.addScanIterator(is);
-        bs.setRanges(ranges);
-
-        return bs;
-
-    } catch (TableNotFoundException e) {
-        e.printStackTrace();
-    } catch (AccumuloException e) {
-        e.printStackTrace();
-    } catch (AccumuloSecurityException e) {
-        e.printStackTrace();
     }
-        throw new QueryEvaluationException();
-   }
-
 
     @Override
     public void close() throws IOException {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
@@ -118,6 +118,12 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
     public String getTableName() {
         return getTableName(conf);
     }
+    
+    /**
+     * Get the Accumulo table that will be used by this index.  
+     * @param conf
+     * @return table name guaranteed to be used by instances of this index
+     */
     public static String getTableName(Configuration conf) {
         return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
     }

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
@@ -77,7 +77,7 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
 
     private void initInternal() throws AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException,
             TableExistsException {
-        ConfigUtils.createTableIfNotExists(conf, ConfigUtils.getEntityTableName(conf));
+        ConfigUtils.createTableIfNotExists(conf, getTableName());
     }
 
     @Override
@@ -118,7 +118,10 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
 
     @Override
     public String getTableName() {
-        return ConfigUtils.getEntityTableName(conf);
+        return getTableName(conf);
+    }
+    public static String getTableName(Configuration conf) {
+        return ConfigUtils.getTablePrefix(conf)  + "entity";
     }
 
     @Override

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/entity/EntityCentricIndex.java
@@ -73,8 +73,6 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
     private BatchWriter writer;
     private boolean isInit = false;
 
-    public static final String CONF_TABLE_SUFFIX = "ac.indexer.eci.tablename";
-
     private void initInternal() throws AccumuloException, AccumuloSecurityException, TableNotFoundException, IOException,
             TableExistsException {
         ConfigUtils.createTableIfNotExists(conf, getTableName());
@@ -121,7 +119,7 @@ public class EntityCentricIndex extends AbstractAccumuloIndexer {
         return getTableName(conf);
     }
     public static String getTableName(Configuration conf) {
-        return ConfigUtils.getTablePrefix(conf)  + "entity";
+        return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
     }
 
     @Override

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexer.java
@@ -26,6 +26,8 @@ import static mvm.rya.indexing.accumulo.freetext.query.ASTNodeUtils.getNodeItera
 import java.io.IOException;
 import java.nio.charset.CharacterCodingException;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -185,6 +187,10 @@ import mvm.rya.indexing.accumulo.freetext.query.TokenMgrError;
  * <pre>
  */
 public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements FreeTextIndexer  {
+    private static final String TABLE_SUFFIX_TERM = "freetext_term";
+
+    private static final String TABLE_SUFFFIX_DOC = "freetext";
+
     private static final Logger logger = Logger.getLogger(AccumuloFreeTextIndexer.class);
 
     private static final boolean IS_TERM_TABLE_TOKEN_DELETION_ENABLED = true;
@@ -598,23 +604,42 @@ public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements 
         return root;
     }
 
-
+    /**
+     * Get Free Text Document index table's name 
+     * Use the two table version of this below. This one is required by base class. 
+     */
     @Override
     public String getTableName() {
        return getFreeTextDocTablename(conf);
-       // TODO: use the two table version of this below, base class should return a list.
     }
-    public static String[] getTableNames(Configuration conf) {
-        return new String[] { 
-        		getFreeTextDocTablename(conf),
-        		getFreeTextTermTablename(conf) };
-     }
+    
+    /**
+     * Get all the tables used by this index.
+     * @param conf configuration map
+     * @return an unmodifiable list of all the table names.
+     */
+    public static List<String> getTableNames(Configuration conf) {
+        return Collections.unmodifiableList( Arrays.asList( 
+                getFreeTextDocTablename(conf),
+                getFreeTextTermTablename(conf) ));
+    }
+    
+    /**
+     * Get the Document index's table name.
+     * @param conf
+     * @return the Free Text Document index table's name
+     */
     public static String getFreeTextDocTablename(Configuration conf) {
-        return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + "freetext";
+        return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFFIX_DOC;
     }
 
+    /**
+     * Get the Term index's table name.
+     * @param conf
+     * @return the Free Text Term index table's name
+     */
     public static String getFreeTextTermTablename(Configuration conf) {
-        return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + "freetext_term";
+        return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX_TERM;
     }
 
     private void deleteStatement(Statement statement) throws IOException {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexer.java
@@ -212,8 +212,8 @@ public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements 
 
     private void initInternal() throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
             TableExistsException {
-        String doctable = ConfigUtils.getFreeTextDocTablename(conf);
-        String termtable = ConfigUtils.getFreeTextTermTablename(conf);
+        String doctable = getFreeTextDocTablename(conf);
+        String termtable = getFreeTextTermTablename(conf);
 
         docTableNumPartitions = ConfigUtils.getFreeTextDocNumPartitions(conf);
         int termTableNumPartitions = ConfigUtils.getFreeTextTermNumPartitions(conf);
@@ -397,7 +397,7 @@ public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements 
     }
 
     private Set<String> unrollWildcard(String string, boolean reverse) throws IOException {
-        Scanner termTableScan = getScanner(ConfigUtils.getFreeTextTermTablename(conf));
+        Scanner termTableScan = getScanner(getFreeTextTermTablename(conf));
 
         Set<String> unrolledTerms = new HashSet<String>();
 
@@ -482,7 +482,7 @@ public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements 
     @Override
     public CloseableIteration<Statement, QueryEvaluationException> queryText(String query, StatementConstraints contraints)
             throws IOException {
-        Scanner docTableScan = getScanner(ConfigUtils.getFreeTextDocTablename(conf));
+        Scanner docTableScan = getScanner(getFreeTextDocTablename(conf));
 
         // test the query to see if it's parses correctly.
         SimpleNode root = parseQuery(query);
@@ -601,7 +601,20 @@ public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements 
 
     @Override
     public String getTableName() {
-       return ConfigUtils.getFreeTextDocTablename(conf);
+       return getFreeTextDocTablename(conf);
+       // TODO: use the two table version of this below, base class should return a list.
+    }
+    public static String[] getTableNames(Configuration conf) {
+        return new String[] { 
+        		getFreeTextDocTablename(conf),
+        		getFreeTextTermTablename(conf) };
+     }
+    public static String getFreeTextDocTablename(Configuration conf) {
+        return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + "freetext";
+    }
+
+    public static String getFreeTextTermTablename(Configuration conf) {
+        return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + "freetext_term";
     }
 
     private void deleteStatement(Statement statement) throws IOException {
@@ -682,7 +695,7 @@ public class AccumuloFreeTextIndexer extends AbstractAccumuloIndexer implements 
      */
     private boolean doesTermExistInOtherDocs(String term, int currentDocId, Text docIdText) {
         try {
-            String freeTextDocTableName = ConfigUtils.getFreeTextDocTablename(conf);
+            String freeTextDocTableName = getFreeTextDocTablename(conf);
             Scanner scanner = getScanner(freeTextDocTableName);
 
             String t = StringUtils.removeEnd(term, "*").toLowerCase();

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
@@ -447,7 +447,7 @@ public class GeoMesaGeoIndexer extends AbstractAccumuloIndexer implements GeoInd
      */
     public static String getTableName(Configuration conf) {
         return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
-}
+    }
 
     private void deleteStatements(final Collection<RyaStatement> ryaStatements) throws IOException {
         // create a feature collection

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
@@ -439,6 +439,12 @@ public class GeoMesaGeoIndexer extends AbstractAccumuloIndexer implements GeoInd
     public String getTableName() {
             return getTableName(conf);
     }
+
+    /**
+     * Get the Accumulo table that will be used by this index.  
+     * @param conf
+     * @return table name guaranteed to be used by instances of this index
+     */
     public static String getTableName(Configuration conf) {
         return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
 }

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
@@ -190,7 +190,7 @@ public class GeoMesaGeoIndexer extends AbstractAccumuloIndexer implements GeoInd
         final String user = ConfigUtils.getUsername(conf);
         final String password = ConfigUtils.getPassword(conf);
         final String auths = ConfigUtils.getAuthorizations(conf).toString();
-        final String tableName = ConfigUtils.getGeoTablename(conf);
+        final String tableName = getTableName(conf);
         final int numParitions = ConfigUtils.getGeoNumPartitions(conf);
 
         final String featureSchemaFormat = "%~#s%" + numParitions + "#r%" + FEATURE_NAME
@@ -435,8 +435,11 @@ public class GeoMesaGeoIndexer extends AbstractAccumuloIndexer implements GeoInd
 
     @Override
     public String getTableName() {
-       return ConfigUtils.getGeoTablename(conf);
+            return getTableName(conf);
     }
+    public static String getTableName(Configuration conf) {
+        return ConfigUtils.getTablePrefix(conf)  + "geo";
+}
 
     private void deleteStatements(final Collection<RyaStatement> ryaStatements) throws IOException {
         // create a feature collection

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/geo/GeoMesaGeoIndexer.java
@@ -124,6 +124,8 @@ import mvm.rya.indexing.accumulo.ConfigUtils;
  */
 public class GeoMesaGeoIndexer extends AbstractAccumuloIndexer implements GeoIndexer  {
 
+    private static final String TABLE_SUFFIX = "geo";
+
     private static final Logger logger = Logger.getLogger(GeoMesaGeoIndexer.class);
 
     private static final String FEATURE_NAME = "RDF";
@@ -438,7 +440,7 @@ public class GeoMesaGeoIndexer extends AbstractAccumuloIndexer implements GeoInd
             return getTableName(conf);
     }
     public static String getTableName(Configuration conf) {
-        return ConfigUtils.getTablePrefix(conf)  + "geo";
+        return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
 }
 
     private void deleteStatements(final Collection<RyaStatement> ryaStatements) throws IOException {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexer.java
@@ -77,6 +77,8 @@ import mvm.rya.indexing.accumulo.ConfigUtils;
 
 public class AccumuloTemporalIndexer extends AbstractAccumuloIndexer implements TemporalIndexer {
 
+    private static final String TABLE_SUFFIX = "temporal";
+
     private static final Logger logger = Logger.getLogger(AccumuloTemporalIndexer.class);
 
     private static final String CF_INTERVAL = "interval";
@@ -878,7 +880,7 @@ public class AccumuloTemporalIndexer extends AbstractAccumuloIndexer implements 
 
     @Override
     public String getTableName() {
-       return ConfigUtils.getTablePrefix(conf)  + "temporal";
+       return ConfigUtils.getTablePrefix(conf)  + TABLE_SUFFIX;
     }
 
     private void deleteStatement(final Statement statement) throws IOException, IllegalArgumentException {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexer.java
@@ -103,7 +103,7 @@ public class AccumuloTemporalIndexer extends AbstractAccumuloIndexer implements 
 
     private void initInternal() throws AccumuloException, AccumuloSecurityException, TableNotFoundException,
             TableExistsException {
-        temporalIndexTableName = ConfigUtils.getTemporalTableName(conf);
+        temporalIndexTableName = getTableName();
         // Create one index table on first run.
         ConfigUtils.createTableIfNotExists(conf, temporalIndexTableName);
 
@@ -878,7 +878,7 @@ public class AccumuloTemporalIndexer extends AbstractAccumuloIndexer implements 
 
     @Override
     public String getTableName() {
-       return ConfigUtils.getTemporalTableName(conf);
+       return ConfigUtils.getTablePrefix(conf)  + "temporal";
     }
 
     private void deleteStatement(final Statement statement) throws IOException, IllegalArgumentException {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/external/tupleSet/AccumuloIndexSet.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/external/tupleSet/AccumuloIndexSet.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.Text;
 import org.apache.rya.indexing.pcj.storage.PcjException;
 import org.apache.rya.indexing.pcj.storage.PcjMetadata;
+import org.apache.rya.indexing.pcj.storage.PrecomputedJoinStorage.PCJStorageException;
 import org.apache.rya.indexing.pcj.storage.accumulo.AccumuloPcjSerializer;
 import org.apache.rya.indexing.pcj.storage.accumulo.BindingSetConverter.BindingSetConversionException;
 import org.apache.rya.indexing.pcj.storage.accumulo.PcjTables;
@@ -142,10 +143,11 @@ public class AccumuloIndexSet extends ExternalTupleSet implements
 	 * @throws TableNotFoundException
 	 * @throws AccumuloSecurityException
 	 * @throws AccumuloException
+	 * @throws PCJStorageException 
 	 */
 	public AccumuloIndexSet(String sparql, Configuration conf,
 			String tablename) throws MalformedQueryException, SailException,
-			QueryEvaluationException, TableNotFoundException, AccumuloException, AccumuloSecurityException {
+			QueryEvaluationException, TableNotFoundException, AccumuloException, AccumuloSecurityException, PCJStorageException {
 		this.tablename = tablename;
 		this.accCon = ConfigUtils.getConnector(conf);
 		this.auths = getAuthorizations(conf);
@@ -163,11 +165,7 @@ public class AccumuloIndexSet extends ExternalTupleSet implements
 		}
 		setProjectionExpr(projection.get());
 		Set<VariableOrder> orders = null;
-		try {
-			orders = pcj.getPcjMetadata(accCon, tablename).getVarOrders();
-		} catch (final PcjException e) {
-			e.printStackTrace();
-		}
+		orders = pcj.getPcjMetadata(accCon, tablename).getVarOrders();
 
 		varOrder = Lists.newArrayList();
 		for (final VariableOrder var : orders) {

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
@@ -57,6 +57,6 @@ public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorag
 
     @Override
     public String getCollectionName() {
-        return ConfigUtils.getFreeTextDocTablename(conf);
+    	return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + "freetext";
     }
 }

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/freetext/MongoFreeTextIndexer.java
@@ -34,6 +34,7 @@ import mvm.rya.indexing.accumulo.ConfigUtils;
 import mvm.rya.indexing.mongodb.AbstractMongoIndexer;
 
 public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorageStrategy> implements FreeTextIndexer {
+    private static final String COLLECTION_SUFFIX = "freetext";
     private static final Logger logger = Logger.getLogger(MongoFreeTextIndexer.class);
 
     public MongoFreeTextIndexer(final MongoClient mongoClient) {
@@ -57,6 +58,6 @@ public class MongoFreeTextIndexer extends AbstractMongoIndexer<TextMongoDBStorag
 
     @Override
     public String getCollectionName() {
-    	return mvm.rya.indexing.accumulo.ConfigUtils.getTablePrefix(conf)  + "freetext";
+    	return ConfigUtils.getTablePrefix(conf)  + COLLECTION_SUFFIX;
     }
 }

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/geo/MongoGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/geo/MongoGeoIndexer.java
@@ -113,6 +113,6 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
 
     @Override
     public String getCollectionName() {
-        return ConfigUtils.getGeoTablename(conf);
+        return ConfigUtils.getTablePrefix(conf)  + "geo";
     }
 }

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/geo/MongoGeoIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/geo/MongoGeoIndexer.java
@@ -41,6 +41,7 @@ import mvm.rya.indexing.mongodb.geo.GeoMongoDBStorageStrategy.GeoQuery;
 import mvm.rya.mongodb.MongoDBRdfConfiguration;
 
 public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrategy> implements GeoIndexer {
+    private static final String COLLECTION_SUFFIX = "geo";
     private static final Logger logger = Logger.getLogger(MongoGeoIndexer.class);
 
     public MongoGeoIndexer(final MongoClient mongoClient) {
@@ -113,6 +114,6 @@ public class MongoGeoIndexer extends AbstractMongoIndexer<GeoMongoDBStorageStrat
 
     @Override
     public String getCollectionName() {
-        return ConfigUtils.getTablePrefix(conf)  + "geo";
+        return ConfigUtils.getTablePrefix(conf)  + COLLECTION_SUFFIX;
     }
 }

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
@@ -45,6 +45,7 @@ import mvm.rya.indexing.mongodb.AbstractMongoIndexer;
  * Indexes MongoDB based on time instants or intervals.
  */
 public class MongoTemporalIndexer extends AbstractMongoIndexer<TemporalMongoDBStorageStrategy> implements TemporalIndexer {
+    private static final String COLLECTION_SUFFIX = "temporal";
     private static final Logger LOG = Logger.getLogger(MongoTemporalIndexer.class);
 
     /**
@@ -150,7 +151,7 @@ public class MongoTemporalIndexer extends AbstractMongoIndexer<TemporalMongoDBSt
 
     @Override
     public String getCollectionName() {
-        return ConfigUtils.getTablePrefix(conf)  + "temporal";
+        return ConfigUtils.getTablePrefix(conf)  + COLLECTION_SUFFIX;
     }
 
     @VisibleForTesting

--- a/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/mongodb/temporal/MongoTemporalIndexer.java
@@ -150,7 +150,7 @@ public class MongoTemporalIndexer extends AbstractMongoIndexer<TemporalMongoDBSt
 
     @Override
     public String getCollectionName() {
-        return ConfigUtils.getTemporalTableName(conf);
+        return ConfigUtils.getTablePrefix(conf)  + "temporal";
     }
 
     @VisibleForTesting

--- a/extras/indexing/src/main/java/mvm/rya/indexing/pcj/matching/PCJOptimizer.java
+++ b/extras/indexing/src/main/java/mvm/rya/indexing/pcj/matching/PCJOptimizer.java
@@ -122,7 +122,7 @@ public class PCJOptimizer implements QueryOptimizer, Configurable {
                     | QueryEvaluationException | TableNotFoundException
                     | AccumuloException | AccumuloSecurityException
                     | PcjException e) {
-                e.printStackTrace();
+                throw new Error(e);
             }
             init = true;
         }
@@ -334,9 +334,11 @@ public class PCJOptimizer implements QueryOptimizer, Configurable {
         } else {
             //if no tables are provided by user, get ids for rya instance id, create table name,
             //and associate table name with sparql
+            // TODO: storage.listPcjs() returns tablenames, not PCJ-IDs.  
+            //     See mvm.rya.indexing.external.accumulo.AccumuloPcjStorage.dropPcj(String)
             List<String> ids = storage.listPcjs();
             for(String id: ids) {
-                indexTables.put(pcjFactory.makeTableName(tablePrefix, id), storage.getPcjMetadata(id).getSparql());
+                indexTables.put(id, storage.getPcjMetadata(id).getSparql());
             }
         }
 

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
@@ -49,7 +49,7 @@ import com.google.common.collect.Sets;
 
 
 import info.aduna.iteration.CloseableIteration;
-
+import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.domain.RyaType;
@@ -62,17 +62,17 @@ import mvm.rya.indexing.accumulo.ConfigUtils;
 public class AccumuloFreeTextIndexerTest {
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
-    Configuration conf;
+    AccumuloRdfConfiguration conf;
 
     @Before
     public void before() throws Exception {
-        conf = new Configuration();
+        conf = new AccumuloRdfConfiguration();
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");
         conf.set(ConfigUtils.CLOUDBASE_AUTHS, "U");
         conf.setClass(ConfigUtils.TOKENIZER_CLASS, SimpleTokenizer.class, Tokenizer.class);
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX,"triplestore_");
+        conf.setTablePrefix("triplestore_");
         
         // If a table exists from last time, delete it.
         List<String> tableNames = AccumuloFreeTextIndexer.getTableNames(conf);

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
@@ -1,6 +1,7 @@
 package mvm.rya.indexing.accumulo.freetext;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -13,6 +14,7 @@ import org.apache.accumulo.core.client.admin.TableOperations;
 import org.apache.accumulo.core.data.Key;
 import org.apache.accumulo.core.security.Authorizations;
 import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openrdf.model.Statement;
@@ -47,7 +49,7 @@ import com.google.common.collect.Sets;
 
 
 import info.aduna.iteration.CloseableIteration;
-import junit.framework.Assert;
+
 import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.domain.RyaType;
@@ -73,9 +75,10 @@ public class AccumuloFreeTextIndexerTest {
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX,"triplestore_");
         
         // If a table exists from last time, delete it.
-        String[] tableNames = AccumuloFreeTextIndexer.getTableNames(conf);
-        for (String name : tableNames)
-        	destroyTable(conf, name);
+        List<String> tableNames = AccumuloFreeTextIndexer.getTableNames(conf);
+        for (String name : tableNames) {
+            destroyTable(conf, name);
+        }
         // Tables are created in each test with setConf(conf)
     }
 

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/freetext/AccumuloFreeTextIndexerTest.java
@@ -48,6 +48,7 @@ import com.google.common.collect.Sets;
 
 import info.aduna.iteration.CloseableIteration;
 import junit.framework.Assert;
+import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.domain.RyaType;
 import mvm.rya.api.domain.RyaURI;
@@ -63,28 +64,27 @@ public class AccumuloFreeTextIndexerTest {
 
     @Before
     public void before() throws Exception {
-        String tableName = "triplestore_freetext";
-        String termTableName = "triplestore_freetext_term";
         conf = new Configuration();
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");
-        conf.set(ConfigUtils.FREE_TEXT_DOC_TABLENAME, tableName);
-        conf.set(ConfigUtils.FREE_TEXT_TERM_TABLENAME, termTableName);
         conf.set(ConfigUtils.CLOUDBASE_AUTHS, "U");
         conf.setClass(ConfigUtils.TOKENIZER_CLASS, SimpleTokenizer.class, Tokenizer.class);
-
-        createTable(conf, tableName);
-        createTable(conf, termTableName);
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX,"triplestore_");
+        
+        // If a table exists from last time, delete it.
+        String[] tableNames = AccumuloFreeTextIndexer.getTableNames(conf);
+        for (String name : tableNames)
+        	destroyTable(conf, name);
+        // Tables are created in each test with setConf(conf)
     }
 
-    private static void createTable(Configuration conf, String tablename) throws AccumuloException, AccumuloSecurityException,
+    private static void destroyTable(Configuration conf, String tablename) throws AccumuloException, AccumuloSecurityException,
             TableNotFoundException, TableExistsException {
         TableOperations tableOps = ConfigUtils.getConnector(conf).tableOperations();
         if (tableOps.exists(tablename)) {
             tableOps.delete(tablename);
         }
-        tableOps.create(tablename);
     }
 
     @Test

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerSfTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerSfTest.java
@@ -26,6 +26,8 @@ import info.aduna.iteration.CloseableIteration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
+import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.resolver.RdfToRyaConversions;
@@ -36,7 +38,6 @@ import mvm.rya.indexing.accumulo.geo.GeoConstants;
 import mvm.rya.indexing.accumulo.geo.GeoMesaGeoIndexer;
 
 import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -64,7 +65,7 @@ import com.vividsolutions.jts.geom.impl.PackedCoordinateSequence;
  * Tests all of the "simple functions" of the geoindexer.
  */
 public class GeoIndexerSfTest {
-    private static Configuration conf;
+    private static AccumuloRdfConfiguration conf;
     private static GeometryFactory gf = new GeometryFactory(new PrecisionModel(), 4326);
     private static GeoMesaGeoIndexer g;
 
@@ -108,8 +109,8 @@ public class GeoIndexerSfTest {
 
     @Before
     public void before() throws Exception {
-        conf = new Configuration();
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
+        conf = new AccumuloRdfConfiguration();
+        conf.setTablePrefix("triplestore_");
         String tableName = GeoMesaGeoIndexer.getTableName(conf);
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerSfTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerSfTest.java
@@ -26,14 +26,10 @@ import info.aduna.iteration.CloseableIteration;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.UUID;
-
-import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.resolver.RdfToRyaConversions;
 import mvm.rya.api.resolver.RyaToRdfConversions;
-import mvm.rya.indexing.GeoIndexer;
 import mvm.rya.indexing.StatementConstraints;
 import mvm.rya.indexing.accumulo.ConfigUtils;
 import mvm.rya.indexing.accumulo.geo.GeoConstants;
@@ -112,10 +108,9 @@ public class GeoIndexerSfTest {
 
     @Before
     public void before() throws Exception {
-        //System.out.println(UUID.randomUUID().toString());
         conf = new Configuration();
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
-        String tableName = GeoMesaGeoIndexer.getTableName(conf);// was "triplestore_geospacial";
+        String tableName = GeoMesaGeoIndexer.getTableName(conf);
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerSfTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerSfTest.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 
 import mvm.rya.accumulo.AccumuloRdfConfiguration;
+import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.resolver.RdfToRyaConversions;
 import mvm.rya.api.resolver.RyaToRdfConversions;
@@ -111,13 +112,13 @@ public class GeoIndexerSfTest {
 
     @Before
     public void before() throws Exception {
-        System.out.println(UUID.randomUUID().toString());
-        String tableName = "triplestore_geospacial";
+        //System.out.println(UUID.randomUUID().toString());
         conf = new Configuration();
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
+        String tableName = GeoMesaGeoIndexer.getTableName(conf);// was "triplestore_geospacial";
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");
-        conf.set(ConfigUtils.GEO_TABLENAME, tableName);
         conf.set(ConfigUtils.CLOUDBASE_AUTHS, "U");
 
         TableOperations tops = ConfigUtils.getConnector(conf).tableOperations();

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerTest.java
@@ -65,10 +65,9 @@ public class GeoIndexerTest {
 
     @Before
     public void before() throws Exception {
-        //System.out.println(UUID.randomUUID().toString());
         conf = new Configuration();
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
-        String tableName = GeoMesaGeoIndexer.getTableName(conf);// was "triplestore_geospacial";
+        String tableName = GeoMesaGeoIndexer.getTableName(conf);
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerTest.java
@@ -52,6 +52,7 @@ import com.vividsolutions.jts.geom.PrecisionModel;
 import com.vividsolutions.jts.geom.impl.PackedCoordinateSequence;
 
 import info.aduna.iteration.CloseableIteration;
+import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.indexing.StatementConstraints;
 import mvm.rya.indexing.accumulo.ConfigUtils;
 
@@ -64,13 +65,13 @@ public class GeoIndexerTest {
 
     @Before
     public void before() throws Exception {
-        System.out.println(UUID.randomUUID().toString());
-        String tableName = "triplestore_geospacial";
+        //System.out.println(UUID.randomUUID().toString());
         conf = new Configuration();
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
+        String tableName = GeoMesaGeoIndexer.getTableName(conf);// was "triplestore_geospacial";
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "PASS");
-        conf.set(ConfigUtils.GEO_TABLENAME, tableName);
         conf.set(ConfigUtils.CLOUDBASE_AUTHS, "U");
 
         TableOperations tops = ConfigUtils.getConnector(conf).tableOperations();

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/geo/GeoIndexerTest.java
@@ -26,10 +26,7 @@ import static mvm.rya.api.resolver.RdfToRyaConversions.convertStatement;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.UUID;
-
 import org.apache.accumulo.core.client.admin.TableOperations;
-import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +49,7 @@ import com.vividsolutions.jts.geom.PrecisionModel;
 import com.vividsolutions.jts.geom.impl.PackedCoordinateSequence;
 
 import info.aduna.iteration.CloseableIteration;
+import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.indexing.StatementConstraints;
 import mvm.rya.indexing.accumulo.ConfigUtils;
@@ -60,13 +58,13 @@ public class GeoIndexerTest {
 
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
-    Configuration conf;
+    AccumuloRdfConfiguration conf;
     GeometryFactory gf = new GeometryFactory(new PrecisionModel(), 4326);
 
     @Before
     public void before() throws Exception {
-        conf = new Configuration();
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
+        conf = new AccumuloRdfConfiguration();
+        conf.setTablePrefix("triplestore_");
         String tableName = GeoMesaGeoIndexer.getTableName(conf);
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
         conf.set(ConfigUtils.CLOUDBASE_USER, "USERNAME");

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexerTest.java
@@ -92,6 +92,9 @@ import mvm.rya.indexing.accumulo.ConfigUtils;
  *   Instance {hasBeginning, hasEnd} given Interval
  * And a few more.
  *
+ *  The temporal predicates are from these ontologies: 
+ *      http://linkedevents.org/ontology
+ *      http://motools.sourceforge.net/event/event.html
  */
 public final class AccumuloTemporalIndexerTest {
     // Configuration properties, this is reset per test in setup.
@@ -105,13 +108,7 @@ public final class AccumuloTemporalIndexerTest {
     private static final String STAT_COUNT = "count";
     private static final String STAT_KEYHASH = "keyhash";
     private static final String STAT_VALUEHASH = "valuehash";
-//    private static final String TEST_TEMPORAL_INDEX_TABLE_NAME = "testTemporalIndex";
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
-
-    // Recreate table name for each test instance in this JVM.
-    //String uniquePerTestTemporalIndexTableName = TEST_TEMPORAL_INDEX_TABLE_NAME + String.format("%05d", nextTableSuffixAtomic.getAndIncrement());
-    // start at 0, for uniqueness between jvm's consider AtomicLong(new Random().nextLong())
-//    private static final AtomicLong nextTableSuffixAtomic = new AtomicLong();
 
     // Assign this in setUpBeforeClass, store them in each test.
     // setup() deletes table before each test.
@@ -209,18 +206,6 @@ public final class AccumuloTemporalIndexerTest {
     public static void setUpBeforeClass() throws Exception {
     }
 
-//    /**
-//     * Create a table for test after deleting it.
-//     */
-//    private static void createTable(Configuration conf, String tablename)
-//            throws AccumuloException, AccumuloSecurityException, TableNotFoundException, TableExistsException {
-//        TableOperations tableOps = ConfigUtils.getConnector(conf).tableOperations();
-//        if (tableOps.exists(tablename)) {
-//            tableOps.delete(tablename);
-//        }
-//        tableOps.create(tablename);
-//    }
-
     /**
      * @throws java.lang.Exception
      */
@@ -236,7 +221,7 @@ public final class AccumuloTemporalIndexerTest {
         conf = new Configuration();
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
-        // This is from http://linkedevents.org/ontology
+        // The temporal predicates are from http://linkedevents.org/ontology
         // and http://motools.sourceforge.net/event/event.html
         conf.setStrings(ConfigUtils.TEMPORAL_PREDICATES_LIST, ""
                 + URI_PROPERTY_AT_TIME + ","
@@ -992,7 +977,7 @@ public final class AccumuloTemporalIndexerTest {
         long keyHasher = 0;
         long valueHasher = 0;
         final String indexTableName = tIndexer.getTableName();
-		out.println("Reading : " + indexTableName);
+        out.println("Reading : " + indexTableName);
         out.format(FORMAT, "--Row--", "--ColumnFamily--", "--ColumnQualifier--", "--Value--");
 
         Scanner s = ConfigUtils.getConnector(conf).createScanner(indexTableName, Authorizations.EMPTY);

--- a/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/accumulo/temporal/AccumuloTemporalIndexerTest.java
@@ -21,9 +21,8 @@ package mvm.rya.indexing.accumulo.temporal;
 
 
 import static mvm.rya.api.resolver.RdfToRyaConversions.convertStatement;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
+import static org.junit.Assert.*; 
+import org.junit.Assert; 
 import java.io.IOException;
 import java.io.PrintStream;
 import java.security.NoSuchAlgorithmException;
@@ -36,8 +35,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.accumulo.core.client.AccumuloException;
 import org.apache.accumulo.core.client.AccumuloSecurityException;
 import org.apache.accumulo.core.client.Scanner;
@@ -67,7 +64,7 @@ import org.openrdf.query.QueryEvaluationException;
 import com.beust.jcommander.internal.Lists;
 
 import info.aduna.iteration.CloseableIteration;
-import junit.framework.Assert;
+import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.indexing.StatementConstraints;
 import mvm.rya.indexing.StatementSerializer;
@@ -108,13 +105,13 @@ public final class AccumuloTemporalIndexerTest {
     private static final String STAT_COUNT = "count";
     private static final String STAT_KEYHASH = "keyhash";
     private static final String STAT_VALUEHASH = "valuehash";
-    private static final String TEST_TEMPORAL_INDEX_TABLE_NAME = "testTemporalIndex";
+//    private static final String TEST_TEMPORAL_INDEX_TABLE_NAME = "testTemporalIndex";
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
     // Recreate table name for each test instance in this JVM.
-    String uniquePerTestTemporalIndexTableName = TEST_TEMPORAL_INDEX_TABLE_NAME + String.format("%05d", nextTableSuffixAtomic.getAndIncrement());
+    //String uniquePerTestTemporalIndexTableName = TEST_TEMPORAL_INDEX_TABLE_NAME + String.format("%05d", nextTableSuffixAtomic.getAndIncrement());
     // start at 0, for uniqueness between jvm's consider AtomicLong(new Random().nextLong())
-    private static final AtomicLong nextTableSuffixAtomic = new AtomicLong();
+//    private static final AtomicLong nextTableSuffixAtomic = new AtomicLong();
 
     // Assign this in setUpBeforeClass, store them in each test.
     // setup() deletes table before each test.
@@ -212,17 +209,17 @@ public final class AccumuloTemporalIndexerTest {
     public static void setUpBeforeClass() throws Exception {
     }
 
-    /**
-     * Create a table for test after deleting it.
-     */
-    private static void createTable(Configuration conf, String tablename)
-            throws AccumuloException, AccumuloSecurityException, TableNotFoundException, TableExistsException {
-        TableOperations tableOps = ConfigUtils.getConnector(conf).tableOperations();
-        if (tableOps.exists(tablename)) {
-            tableOps.delete(tablename);
-        }
-        tableOps.create(tablename);
-    }
+//    /**
+//     * Create a table for test after deleting it.
+//     */
+//    private static void createTable(Configuration conf, String tablename)
+//            throws AccumuloException, AccumuloSecurityException, TableNotFoundException, TableExistsException {
+//        TableOperations tableOps = ConfigUtils.getConnector(conf).tableOperations();
+//        if (tableOps.exists(tablename)) {
+//            tableOps.delete(tablename);
+//        }
+//        tableOps.create(tablename);
+//    }
 
     /**
      * @throws java.lang.Exception
@@ -237,8 +234,8 @@ public final class AccumuloTemporalIndexerTest {
     @Before
     public void setUp() throws Exception {
         conf = new Configuration();
+        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "triplestore_");
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
-        conf.set(ConfigUtils.TEMPORAL_TABLENAME, uniquePerTestTemporalIndexTableName);
         // This is from http://linkedevents.org/ontology
         // and http://motools.sourceforge.net/event/event.html
         conf.setStrings(ConfigUtils.TEMPORAL_PREDICATES_LIST, ""
@@ -246,8 +243,6 @@ public final class AccumuloTemporalIndexerTest {
                 + URI_PROPERTY_CIRCA + ","
                 + URI_PROPERTY_EVENT_TIME);
 
-        // delete and create table
-        createTable(conf, uniquePerTestTemporalIndexTableName);
         tIndexer = new AccumuloTemporalIndexer();
         tIndexer.setConf(conf);
     }
@@ -257,11 +252,12 @@ public final class AccumuloTemporalIndexerTest {
      */
     @After
     public void tearDown() throws Exception {
+    	String indexTableName = tIndexer.getTableName();
         tIndexer.close();
         TableOperations tableOps = ConfigUtils.getConnector(conf).tableOperations();
 
-        if (tableOps.exists(uniquePerTestTemporalIndexTableName))
-            tableOps.delete(uniquePerTestTemporalIndexTableName);
+        if (tableOps.exists(indexTableName))
+            tableOps.delete(indexTableName);
     }
 
     /**
@@ -334,7 +330,7 @@ public final class AccumuloTemporalIndexerTest {
         tIndexer.flush();
 
         int rowsStoredActual = printTables("junit testing: Temporal entities stored in testStoreStatement", null, null);
-        Assert.assertEquals("Number of rows stored.", rowsStoredExpected*4, rowsStoredActual); // 4 index entries per statement
+        assertEquals("Number of rows stored.", rowsStoredExpected*4, rowsStoredActual); // 4 index entries per statement
 
     }
 
@@ -995,10 +991,11 @@ public final class AccumuloTemporalIndexerTest {
         int rowsPrinted = 0;
         long keyHasher = 0;
         long valueHasher = 0;
-        out.println("Reading : " + this.uniquePerTestTemporalIndexTableName);
+        final String indexTableName = tIndexer.getTableName();
+		out.println("Reading : " + indexTableName);
         out.format(FORMAT, "--Row--", "--ColumnFamily--", "--ColumnQualifier--", "--Value--");
 
-        Scanner s = ConfigUtils.getConnector(conf).createScanner(this.uniquePerTestTemporalIndexTableName, Authorizations.EMPTY);
+        Scanner s = ConfigUtils.getConnector(conf).createScanner(indexTableName, Authorizations.EMPTY);
         for (Entry<Key, org.apache.accumulo.core.data.Value> entry : s) {
             rowsPrinted++;
             Key k = entry.getKey();

--- a/extras/indexing/src/test/java/mvm/rya/indexing/external/AccumuloPcjIntegrationTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/external/AccumuloPcjIntegrationTest.java
@@ -31,6 +31,7 @@ import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.persist.RyaDAOException;
 import mvm.rya.indexing.IndexPlanValidator.IndexPlanValidator;
 import mvm.rya.indexing.accumulo.ConfigUtils;
+import mvm.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinStorageType;
 import mvm.rya.indexing.external.tupleSet.AccumuloIndexSet;
 import mvm.rya.indexing.external.tupleSet.ExternalTupleSet;
 import mvm.rya.indexing.pcj.matching.PCJOptimizer;
@@ -1435,11 +1436,12 @@ public class AccumuloPcjIntegrationTest {
 	private static Configuration getConf() {
 		final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
 		conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, true);
-		conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
+		conf.setTablePrefix("rya_");
 		conf.set(ConfigUtils.CLOUDBASE_USER, "root");
 		conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "");
 		conf.set(ConfigUtils.CLOUDBASE_INSTANCE, "instance");
 		conf.set(ConfigUtils.CLOUDBASE_AUTHS, "");
+		conf.set(PrecomputedJoinIndexerConfig.PCJ_STORAGE_TYPE,PrecomputedJoinStorageType.ACCUMULO.name());
 		return conf;
 	}
 

--- a/extras/indexing/src/test/java/mvm/rya/indexing/external/PcjIntegrationTestingUtil.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/external/PcjIntegrationTestingUtil.java
@@ -65,6 +65,7 @@ import com.google.common.collect.Sets;
 import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.persist.RyaDAOException;
 import mvm.rya.indexing.accumulo.ConfigUtils;
+import mvm.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinStorageType;
 import mvm.rya.indexing.external.tupleSet.ExternalTupleSet;
 import mvm.rya.rdftriplestore.inference.InferenceEngineException;
 import mvm.rya.sail.config.RyaSailFactory;
@@ -101,6 +102,7 @@ public class PcjIntegrationTestingUtil {
 
         final AccumuloRdfConfiguration pcjConf = new AccumuloRdfConfiguration();
         pcjConf.set(ConfigUtils.USE_PCJ, "true");
+        pcjConf.set(PrecomputedJoinIndexerConfig.PCJ_STORAGE_TYPE,PrecomputedJoinStorageType.ACCUMULO.name());
         populateTestConfig(instance, tablePrefix, pcjConf);
 
         final Sail pcjSail = RyaSailFactory.getInstance(pcjConf);
@@ -129,6 +131,7 @@ public class PcjIntegrationTestingUtil {
         config.set(ConfigUtils.CLOUDBASE_PASSWORD, "pswd");
         config.set(ConfigUtils.CLOUDBASE_ZOOKEEPERS, "localhost");
         config.setTablePrefix(tablePrefix);
+
     }
 
     public static void closeAndShutdown(final SailRepositoryConnection connection,

--- a/extras/indexing/src/test/java/mvm/rya/indexing/external/tupleSet/AccumuloIndexSetColumnVisibilityTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/external/tupleSet/AccumuloIndexSetColumnVisibilityTest.java
@@ -223,7 +223,7 @@ public class AccumuloIndexSetColumnVisibilityTest {
 
 	private static Configuration getConf() {
 		final AccumuloRdfConfiguration conf = new AccumuloRdfConfiguration();
-		conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
+		conf.setTablePrefix("rya_");
 		conf.set(ConfigUtils.CLOUDBASE_USER, "root");
 		conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "password");
 		conf.set(ConfigUtils.CLOUDBASE_INSTANCE, instance);

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoFreeTextIndexerTest.java
@@ -62,7 +62,7 @@ public class MongoFreeTextIndexerTest {
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
-        conf.set(ConfigUtils.FREE_TEXT_DOC_TABLENAME, "freetext");
+        conf.set(MongoDBRdfConfiguration.CONF_TBL_PREFIX, "another_");
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         mongoClient = testsFactory.newMongo();
    }

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoFreeTextIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoFreeTextIndexerTest.java
@@ -21,7 +21,7 @@ package mvm.rya.indexing.mongo;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.openrdf.model.Statement;
@@ -38,7 +38,7 @@ import com.mongodb.MongoClient;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
 import info.aduna.iteration.CloseableIteration;
-import junit.framework.Assert;
+import mvm.rya.accumulo.AccumuloRdfConfiguration;
 import mvm.rya.api.domain.RyaStatement;
 import mvm.rya.api.domain.RyaType;
 import mvm.rya.api.domain.RyaURI;
@@ -52,17 +52,17 @@ import mvm.rya.mongodb.MongoDBRdfConfiguration;
 public class MongoFreeTextIndexerTest {
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
-    Configuration conf;
+    AccumuloRdfConfiguration conf;
     MongoClient mongoClient;
 
     @Before
     public void before() throws Exception {
-        conf = new Configuration();
+        conf = new AccumuloRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
-        conf.set(MongoDBRdfConfiguration.CONF_TBL_PREFIX, "another_");
+        conf.setTablePrefix("another_");
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         mongoClient = testsFactory.newMongo();
    }

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerSfTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerSfTest.java
@@ -65,7 +65,7 @@ import mvm.rya.mongodb.MongoDBRdfConfiguration;
  * Tests all of the "simple functions" of the geoindexer.
  */
 public class MongoGeoIndexerSfTest {
-    private static Configuration conf;
+    private MongoDBRdfConfiguration conf;
     private static GeometryFactory gf = new GeometryFactory(new PrecisionModel(), 4326);
     private static MongoGeoIndexer g;
 
@@ -110,14 +110,14 @@ public class MongoGeoIndexerSfTest {
     @Before
     public void before() throws Exception {
         System.out.println(UUID.randomUUID().toString());
-        conf = new Configuration();
+        conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");
         conf.set(ConfigUtils.USE_GEO, "true");
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
+        conf.setTablePrefix("rya_");
 
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         final MongoClient mongoClient = testsFactory.newMongo();

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerTest.java
@@ -63,20 +63,20 @@ public class MongoGeoIndexerTest {
 
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
-    Configuration conf;
+    MongoDBRdfConfiguration conf;
     MongoClient mongoClient;
     GeometryFactory gf = new GeometryFactory(new PrecisionModel(), 4326);
 
     @Before
     public void before() throws Exception {
-        conf = new Configuration();
+        conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");
         conf.set(ConfigUtils.USE_GEO, "true");
-        conf.set(MongoDBRdfConfiguration.CONF_TBL_PREFIX, "rya_");
+        conf.setTablePrefix("rya_");
 
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         mongoClient = testsFactory.newMongo();

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoGeoIndexerTest.java
@@ -53,7 +53,6 @@ import com.vividsolutions.jts.geom.impl.PackedCoordinateSequence;
 import de.flapdoodle.embed.mongo.distribution.Version;
 import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
 import info.aduna.iteration.CloseableIteration;
-import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.indexing.StatementConstraints;
 import mvm.rya.indexing.accumulo.ConfigUtils;
 import mvm.rya.indexing.accumulo.geo.GeoConstants;
@@ -77,8 +76,7 @@ public class MongoGeoIndexerTest {
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");
         conf.set(ConfigUtils.USE_GEO, "true");
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, "rya_");
-        conf.set(ConfigUtils.GEO_TABLENAME, "geospacial");
+        conf.set(MongoDBRdfConfiguration.CONF_TBL_PREFIX, "rya_");
 
         final MongodForTestsFactory testsFactory = MongodForTestsFactory.with(Version.Main.PRODUCTION);
         mongoClient = testsFactory.newMongo();

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
@@ -93,11 +93,6 @@ public final class MongoTemporalIndexerTest {
     private static final String STAT_VALUEHASH = "valuehash";
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
-    // Recreate table name for each test instance in this JVM.
-    //String uniquePerTestTemporalIndexTableName = TEST_TEMPORAL_INDEX_TABLE_NAME + String.format("%05d", nextTableSuffixAtomic.getAndIncrement());
-    // start at 0, for uniqueness between jvm's consider AtomicLong(new Random().nextLong())
-    //private static final AtomicLong nextTableSuffixAtomic = new AtomicLong();
-
     // Assign this in setUpBeforeClass, store them in each test.
     // setup() deletes table before each test.
     static final Statement spo_B00_E01;

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
@@ -83,7 +83,7 @@ import mvm.rya.mongodb.MongoDBRdfConfiguration;
  *
  */
 public final class MongoTemporalIndexerTest {
-    Configuration conf;
+    MongoDBRdfConfiguration conf;
     MongoTemporalIndexer tIndexer;
     DBCollection collection;
 
@@ -176,12 +176,12 @@ public final class MongoTemporalIndexerTest {
 
     @Before
     public void before() throws Exception {
-        conf = new Configuration();
+        conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
-        conf.set(MongoDBRdfConfiguration.CONF_TBL_PREFIX, "isthisused_");
+        conf.setTablePrefix("isthisused_");
         
         // This is from http://linkedevents.org/ontology
         // and http://motools.sourceforge.net/event/event.html

--- a/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
+++ b/extras/indexing/src/test/java/mvm/rya/indexing/mongo/MongoTemporalIndexerTest.java
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.accumulo.core.client.TableExistsException;
 import org.apache.accumulo.core.client.TableNotFoundException;
 import org.apache.hadoop.conf.Configuration;
@@ -93,13 +91,12 @@ public final class MongoTemporalIndexerTest {
     private static final String URI_PROPERTY_CIRCA = "Property:circa";
     private static final String URI_PROPERTY_AT_TIME = "Property:atTime";
     private static final String STAT_VALUEHASH = "valuehash";
-    private static final String TEST_TEMPORAL_INDEX_TABLE_NAME = "testTemporalIndex";
     private static final StatementConstraints EMPTY_CONSTRAINTS = new StatementConstraints();
 
     // Recreate table name for each test instance in this JVM.
-    String uniquePerTestTemporalIndexTableName = TEST_TEMPORAL_INDEX_TABLE_NAME + String.format("%05d", nextTableSuffixAtomic.getAndIncrement());
+    //String uniquePerTestTemporalIndexTableName = TEST_TEMPORAL_INDEX_TABLE_NAME + String.format("%05d", nextTableSuffixAtomic.getAndIncrement());
     // start at 0, for uniqueness between jvm's consider AtomicLong(new Random().nextLong())
-    private static final AtomicLong nextTableSuffixAtomic = new AtomicLong();
+    //private static final AtomicLong nextTableSuffixAtomic = new AtomicLong();
 
     // Assign this in setUpBeforeClass, store them in each test.
     // setup() deletes table before each test.
@@ -189,7 +186,8 @@ public final class MongoTemporalIndexerTest {
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, "test");
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, "rya_");
-        conf.set(ConfigUtils.TEMPORAL_TABLENAME, uniquePerTestTemporalIndexTableName);
+        conf.set(MongoDBRdfConfiguration.CONF_TBL_PREFIX, "isthisused_");
+        
         // This is from http://linkedevents.org/ontology
         // and http://motools.sourceforge.net/event/event.html
         conf.setStrings(ConfigUtils.TEMPORAL_PREDICATES_LIST, ""

--- a/extras/indexingExample/src/main/java/EntityDirectExample.java
+++ b/extras/indexingExample/src/main/java/EntityDirectExample.java
@@ -244,7 +244,6 @@ public class EntityDirectExample {
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, USE_MOCK_INSTANCE);
         conf.set(ConfigUtils.USE_ENTITY, "true");
         conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, RYA_TABLE_PREFIX);
-        conf.set(ConfigUtils.ENTITY_TABLENAME, RYA_TABLE_PREFIX + "entity");
         conf.set(ConfigUtils.CLOUDBASE_USER, "root");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "");
         conf.set(ConfigUtils.CLOUDBASE_INSTANCE, INSTANCE);

--- a/extras/indexingExample/src/main/java/EntityDirectExample.java
+++ b/extras/indexingExample/src/main/java/EntityDirectExample.java
@@ -243,7 +243,7 @@ public class EntityDirectExample {
 
         conf.setBoolean(ConfigUtils.USE_MOCK_INSTANCE, USE_MOCK_INSTANCE);
         conf.set(ConfigUtils.USE_ENTITY, "true");
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, RYA_TABLE_PREFIX);
+        conf.setTablePrefix(RYA_TABLE_PREFIX);
         conf.set(ConfigUtils.CLOUDBASE_USER, "root");
         conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "");
         conf.set(ConfigUtils.CLOUDBASE_INSTANCE, INSTANCE);

--- a/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
@@ -43,7 +43,6 @@ import org.openrdf.repository.sail.SailRepository;
 import org.openrdf.repository.sail.SailRepositoryConnection;
 import org.openrdf.sail.Sail;
 
-import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.indexing.accumulo.ConfigUtils;
 import mvm.rya.indexing.accumulo.geo.GeoConstants;
 import mvm.rya.mongodb.MongoDBRdfConfiguration;
@@ -249,15 +248,18 @@ public class MongoRyaDirectExample {
 
     private static Configuration getConf() {
 
-        Configuration conf = new Configuration();
+        MongoDBRdfConfiguration conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
+        // User name and password must be filled in:
+        conf.set(MongoDBRdfConfiguration.MONGO_USER, null);
+        conf.set(MongoDBRdfConfiguration.MONGO_USER_PASSWORD, null);
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, MONGO_DB);
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, MONGO_COLL_PREFIX);
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, "http://www.opengis.net/ont/geosparql#asWKT");
         conf.set(ConfigUtils.USE_GEO, "true");
         conf.set(ConfigUtils.USE_FREETEXT, "true");
-        conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, MONGO_COLL_PREFIX);
+        conf.setTablePrefix(MONGO_COLL_PREFIX);
         conf.set(ConfigUtils.GEO_PREDICATES_LIST, GeoConstants.GEO_AS_WKT.stringValue());
         conf.set(ConfigUtils.FREETEXT_PREDICATES_LIST, RDFS.LABEL.stringValue());
         return conf;

--- a/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/MongoRyaDirectExample.java
@@ -251,8 +251,8 @@ public class MongoRyaDirectExample {
         MongoDBRdfConfiguration conf = new MongoDBRdfConfiguration();
         conf.set(ConfigUtils.USE_MONGO, "true");
         // User name and password must be filled in:
-        conf.set(MongoDBRdfConfiguration.MONGO_USER, null);
-        conf.set(MongoDBRdfConfiguration.MONGO_USER_PASSWORD, null);
+        conf.set(MongoDBRdfConfiguration.MONGO_USER, "fill this in");
+        conf.set(MongoDBRdfConfiguration.MONGO_USER_PASSWORD, "fill this in");
         conf.set(MongoDBRdfConfiguration.USE_TEST_MONGO, "true");
         conf.set(MongoDBRdfConfiguration.MONGO_DB_NAME, MONGO_DB);
         conf.set(MongoDBRdfConfiguration.MONGO_COLLECTION_PREFIX, MONGO_COLL_PREFIX);

--- a/extras/indexingExample/src/main/java/RyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/RyaDirectExample.java
@@ -25,6 +25,8 @@ import mvm.rya.api.RdfCloudTripleStoreConfiguration;
 import mvm.rya.api.persist.RyaDAOException;
 import mvm.rya.indexing.accumulo.ConfigUtils;
 import mvm.rya.indexing.accumulo.geo.GeoConstants;
+import mvm.rya.indexing.external.PrecomputedJoinIndexerConfig;
+import mvm.rya.indexing.external.PrecomputedJoinIndexerConfig.PrecomputedJoinStorageType;
 import mvm.rya.rdftriplestore.inference.InferenceEngineException;
 import mvm.rya.sail.config.RyaSailFactory;
 
@@ -89,7 +91,6 @@ public class RyaDirectExample {
 
 		try {
 			log.info("Connecting to Indexing Sail Repository.");
-			// TODO: this fails here because the Table x_test_triplestore_po is not created.  Possibly creatTables() commented above?
 			final Sail extSail = RyaSailFactory.getInstance(conf);
 			repository = new SailRepository(extSail);
 			repository.initialize();
@@ -156,8 +157,8 @@ public class RyaDirectExample {
 		conf.set(ConfigUtils.USE_GEO, "true");
 		conf.set(ConfigUtils.USE_FREETEXT, "true");
 		conf.set(ConfigUtils.USE_TEMPORAL, "true");
-		conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX,
-				RYA_TABLE_PREFIX);
+		conf.set(PrecomputedJoinIndexerConfig.PCJ_STORAGE_TYPE, PrecomputedJoinStorageType.ACCUMULO.name());
+		conf.set(RdfCloudTripleStoreConfiguration.CONF_TBL_PREFIX, RYA_TABLE_PREFIX);
 		conf.set(ConfigUtils.CLOUDBASE_USER, "root");
 		conf.set(ConfigUtils.CLOUDBASE_PASSWORD, "");
 		conf.set(ConfigUtils.CLOUDBASE_INSTANCE, INSTANCE);

--- a/extras/indexingExample/src/main/java/RyaDirectExample.java
+++ b/extras/indexingExample/src/main/java/RyaDirectExample.java
@@ -89,7 +89,7 @@ public class RyaDirectExample {
 
 		try {
 			log.info("Connecting to Indexing Sail Repository.");
-
+			// TODO: this fails here because the Table x_test_triplestore_po is not created.  Possibly creatTables() commented above?
 			final Sail extSail = RyaSailFactory.getInstance(conf);
 			repository = new SailRepository(extSail);
 			repository.initialize();


### PR DESCRIPTION
Removed table keys and moved their table name methods to secondary index classes, the getTableName() method.  PCJ tests are still broken.
All the secondary indexes are affected because now they manage there own index table names.  Mongo is similar, except they are database names.
